### PR TITLE
Lower peer dep on Cucumber, add peer dep on Protractor

### DIFF
--- a/docs/generalStepDefs.md
+++ b/docs/generalStepDefs.md
@@ -354,7 +354,7 @@ return verifyStepCaptures('the title should equal "My Title"', 'My Title');
 
 ```
 return executeStep('the title should equal "Protractor Integration Test Page"', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -363,7 +363,7 @@ return executeStep('the title should equal "Protractor Integration Test Page"', 
 
 ```
 return executeStep('the title should equal "Fake Title"', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -397,7 +397,7 @@ return verifyStepCaptures('the "Inactive Field" should not be active', 'Inactive
 
 ```
 return executeStep('the "Button" should be active', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -406,7 +406,7 @@ return executeStep('the "Button" should be active', function(stepResult) {
 
 ```
 return executeStep('the "Button" should not be active', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -416,7 +416,7 @@ return executeStep('the "Button" should not be active', function(stepResult) {
 
 ```
 return executeStep('the "Button" should be active', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -425,7 +425,7 @@ return executeStep('the "Button" should be active', function(stepResult) {
 
 ```
 return executeStep('the "Button" should not be active', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -452,7 +452,7 @@ return verifyStepCaptures('the "Home Button" should be present', 'Home Button');
 
 ```
 return executeStep('the "Button" should be present', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -462,7 +462,7 @@ return executeStep('the "Button" should be present', function(stepResult) {
 
 ```
 return executeStep('the "Button" should be present', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -571,7 +571,7 @@ return verifyStepDoesNotCapture('the "Field" should contain the text "Text Strin
 
 ```
 return executeStep('the "Test Span" should contain the text "Span Text"', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -580,7 +580,7 @@ return executeStep('the "Test Span" should contain the text "Span Text"', functi
 
 ```
 return executeStep('the "Test Span" should contain the text "Fake Text"', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -591,7 +591,7 @@ return executeStep('the "Test Span" should contain the text "Fake Text"', functi
 ```
 world.currentPage.testInput.sendKeys("Input Text");
 return executeStep('the "Test Input" should contain the text "Input Text"', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -600,7 +600,7 @@ return executeStep('the "Test Input" should contain the text "Input Text"', func
 
 ```
 return executeStep('the "Test Input" should contain the text "Input Text"', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -626,7 +626,7 @@ return verifyStepCaptures('"Mountain Time" should appear in the "Time Zone" drop
 
 ```
 return executeStep('"Mountain Standard" should appear in the "Time Zone" drop down list', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -635,7 +635,7 @@ return executeStep('"Mountain Standard" should appear in the "Time Zone" drop do
 
 ```
 return executeStep('"Pacific Standard" should appear in the "Time Zone" drop down list', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -669,7 +669,7 @@ return verifyStepCaptures('the "Cancel Button" should not be displayed', 'Cancel
 
 ```
 return executeStep('the "Test Span" should be displayed', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -678,7 +678,7 @@ return executeStep('the "Test Span" should be displayed', function(stepResult) {
 
 ```
 return executeStep('the "Test Span" should not be displayed', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -688,7 +688,7 @@ return executeStep('the "Test Span" should not be displayed', function(stepResul
 
 ```
 return executeStep('the "Test Span" should not be displayed', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -697,7 +697,7 @@ return executeStep('the "Test Span" should not be displayed', function(stepResul
 
 ```
 return executeStep('the "Test Span" should be displayed', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -707,7 +707,7 @@ return executeStep('the "Test Span" should be displayed', function(stepResult) {
 
 ```
 return executeStep('the "Test Span" should not be displayed', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -716,7 +716,7 @@ return executeStep('the "Test Span" should not be displayed', function(stepResul
 
 ```
 return executeStep('the "Test Span" should be displayed', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -770,7 +770,7 @@ return verifyStepDoesNotCapture('the "Username Field" should have the placeholde
 
 ```
 return executeStep('the "Test Input" should have the placeholder text "Test Placeholder"', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -779,7 +779,7 @@ return executeStep('the "Test Input" should have the placeholder text "Test Plac
 
 ```
 return executeStep('the "Test Input" should have the placeholder text "Fake Placeholder"', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -848,7 +848,7 @@ return verifyStepDoesNotCapture('the "Save Configuration" button should be enabl
 
 ```
 return executeStep('the "Test" button should be enabled', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -857,7 +857,7 @@ return executeStep('the "Test" button should be enabled', function(stepResult) {
 
 ```
 return executeStep('the "Test" button should not be enabled', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -867,7 +867,7 @@ return executeStep('the "Test" button should not be enabled', function(stepResul
 
 ```
 return executeStep('the "Test" button should be enabled', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -876,7 +876,7 @@ return executeStep('the "Test" button should be enabled', function(stepResult) {
 
 ```
 return executeStep('the "Test" button should not be enabled', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -916,7 +916,7 @@ return verifyStepDoesNotCapture('"Mountain Standard" should be selected in the "
 
 ```
 return executeStep('"Eastern Standard" should be selected in the "Time Zone" drop down list', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -925,7 +925,7 @@ return executeStep('"Eastern Standard" should be selected in the "Time Zone" dro
 
 ```
 return executeStep('"Mountain Standard" should be selected in the "Time Zone" drop down list', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -966,7 +966,7 @@ return verifyStepMatch('the "Enable Emails" checkbox should not be checked');
 
 ```
 return executeStep('the "Test" checkbox should be checked', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```
 
@@ -975,7 +975,7 @@ return executeStep('the "Test" checkbox should be checked', function(stepResult)
 
 ```
 return executeStep('the "Test" checkbox should not be checked', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -985,7 +985,7 @@ return executeStep('the "Test" checkbox should not be checked', function(stepRes
 
 ```
 return executeStep('the "Test" checkbox should be checked', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.FAILED);
+  return expect(stepResult.isFailed()).to.equal(true);
 });
 ```
 
@@ -994,6 +994,6 @@ return executeStep('the "Test" checkbox should be checked', function(stepResult)
 
 ```
 return executeStep('the "Test" checkbox should not be checked', function(stepResult) {
-  return expect(stepResult.getStatus()).to.equal(Cucumber.Status.PASSED);
+  return expect(stepResult.isSuccessful()).to.equal(true);
 });
 ```

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "devDependencies": {
     "coffee-script": "^1.9.1",
-    "cucumber": "^0.8.0",
+    "cucumber": "^0.5.0",
     "docha": "^0.1.2",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "time-grunt": "^1.0.0"
   },
   "peerDependencies": {
-    "cucumber": ">= 0.5 < 1"
+    "cucumber": ">= 0.5 < 0.7",
+    "protractor": "< 3"
   },
   "homepage": "https://github.com/ReadyTalk/cukefarm",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "devDependencies": {
     "coffee-script": "^1.9.1",
-    "cucumber": "^0.5.0",
+    "cucumber": "^0.6.0",
     "docha": "^0.1.2",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",

--- a/spec/generalStepDefs.spec.coffee
+++ b/spec/generalStepDefs.spec.coffee
@@ -10,7 +10,7 @@ sinonAsPromised = require('sinon-as-promised')(Promise)
 describe 'General Step Defs', ->
 
   supportCodeFilePaths = [rek.path 'GeneralStepDefs']
-  supportCodeLibrary = Cucumber.Cli.SupportCodeLoader(supportCodeFilePaths).getSupportCodeLibrary();
+  supportCodeLibrary = Cucumber.Cli.SupportCodeLoader(supportCodeFilePaths, []).getSupportCodeLibrary();
   ast_tree_walker = new Cucumber.Runtime.AstTreeWalker({}, supportCodeLibrary, {})
 
   scenario =

--- a/spec/generalStepDefs.spec.coffee
+++ b/spec/generalStepDefs.spec.coffee
@@ -10,7 +10,7 @@ sinonAsPromised = require('sinon-as-promised')(Promise)
 describe 'General Step Defs', ->
 
   supportCodeFilePaths = [rek.path 'GeneralStepDefs']
-  supportCodeLibrary = Cucumber.Cli.SupportCodeLoader(supportCodeFilePaths, []).getSupportCodeLibrary();
+  supportCodeLibrary = Cucumber.Cli.SupportCodeLoader(supportCodeFilePaths).getSupportCodeLibrary();
   ast_tree_walker = new Cucumber.Runtime.AstTreeWalker({}, supportCodeLibrary, {})
 
   scenario =
@@ -347,11 +347,11 @@ describe 'General Step Defs', ->
 
       it 'should succeed if the page title matches the supplied title', ->
         executeStep 'the title should equal "Protractor Integration Test Page"', (stepResult) ->
-          expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+          expect(stepResult.isSuccessful()).to.equal true
 
       it 'should fail if the page title does not match the supplied title', ->
         executeStep 'the title should equal "Fake Title"', (stepResult) ->
-          expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+          expect(stepResult.isFailed()).to.equal true
 
   describe 'the "___" should be active', ->
 
@@ -389,11 +389,11 @@ describe 'General Step Defs', ->
 
         it 'should succeed if it expects the element to be active', ->
           executeStep 'the "Button" should be active', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+            expect(stepResult.isSuccessful()).to.equal true
 
         it 'should fail if it expects the element to be inactive', ->
           executeStep 'the "Button" should not be active', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+            expect(stepResult.isFailed()).to.equal true
 
       describe 'with an inactive element', ->
 
@@ -407,11 +407,11 @@ describe 'General Step Defs', ->
 
         it 'should fail if it expects the element to be active', ->
           executeStep 'the "Button" should be active', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+            expect(stepResult.isFailed()).to.equal true
 
         it 'should succeed if it expects the element to be inactive', ->
           executeStep 'the "Button" should not be active', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+            expect(stepResult.isSuccessful()).to.equal true
 
   describe 'the "___" should be present', ->
 
@@ -446,13 +446,13 @@ describe 'General Step Defs', ->
 
         it 'should succeed', ->
           executeStep 'the "Button" should be present', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+            expect(stepResult.isSuccessful()).to.equal true
 
       describe 'without element present', ->
 
         it 'should fail', ->
           executeStep 'the "Button" should be present', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+            expect(stepResult.isFailed()).to.equal true
 
   describe 'I should be on the "___" page', ->
 
@@ -547,11 +547,11 @@ describe 'General Step Defs', ->
 
         it 'should succeed if the element contains the expected text', ->
           executeStep 'the "Test Span" should contain the text "Span Text"', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+            expect(stepResult.isSuccessful()).to.equal true
 
         it 'should fail if the element does not contain the expected text', ->
           executeStep 'the "Test Span" should contain the text "Fake Text"', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+            expect(stepResult.isFailed()).to.equal true
 
       describe 'with an input', ->
 
@@ -566,11 +566,11 @@ describe 'General Step Defs', ->
         it 'should succeed if the element contains the expected text', ->
           world.currentPage.testInput.sendKeys("Input Text")
           executeStep 'the "Test Input" should contain the text "Input Text"', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+            expect(stepResult.isSuccessful()).to.equal true
 
         it 'should fail if the element does not contain the expected text', ->
           executeStep 'the "Test Input" should contain the text "Input Text"', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+            expect(stepResult.isFailed()).to.equal true
 
   describe '"___" should appear in the "___" drop down list', ->
 
@@ -608,11 +608,11 @@ describe 'General Step Defs', ->
 
       it 'should succeed if the expected option is in the drop down list', ->
         executeStep '"Mountain Standard" should appear in the "Time Zone" drop down list', (stepResult) ->
-          expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+          expect(stepResult.isSuccessful()).to.equal true
 
       it 'should fail if the expected option is not in the drop down list', ->
         executeStep '"Pacific Standard" should appear in the "Time Zone" drop down list', (stepResult) ->
-          expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+          expect(stepResult.isFailed()).to.equal true
 
   describe 'the "___" should be displayed', ->
 
@@ -650,11 +650,11 @@ describe 'General Step Defs', ->
 
         it 'should succeed if it expects the element to be displayed', ->
           executeStep 'the "Test Span" should be displayed', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+            expect(stepResult.isSuccessful()).to.equal true
 
         it 'should fail if it expects the element to not be displayed', ->
           executeStep 'the "Test Span" should not be displayed', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+            expect(stepResult.isFailed()).to.equal true
 
       describe 'without the element displayed', ->
 
@@ -668,21 +668,21 @@ describe 'General Step Defs', ->
 
         it 'should succeed if it expects the element to not be displayed', ->
           executeStep 'the "Test Span" should not be displayed', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+            expect(stepResult.isSuccessful()).to.equal true
 
         it 'should fail if it expects the element to be displayed', ->
           executeStep 'the "Test Span" should be displayed', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+            expect(stepResult.isFailed()).to.equal true
 
       describe 'without the element present', ->
 
         it 'should succeed if it expects the element to not be displayed', ->
           executeStep 'the "Test Span" should not be displayed', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+            expect(stepResult.isSuccessful()).to.equal true
 
         it 'should fail if it expects the element to be displayed', ->
           executeStep 'the "Test Span" should be displayed', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+            expect(stepResult.isFailed()).to.equal true
 
   describe 'the "___" should have the placeholder text "___"', ->
 
@@ -727,11 +727,11 @@ describe 'General Step Defs', ->
 
       it 'should succeed if the element contains the expected placeholder text', ->
         executeStep 'the "Test Input" should have the placeholder text "Test Placeholder"', (stepResult) ->
-          expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+          expect(stepResult.isSuccessful()).to.equal true
 
       it 'should fail if the element does not contain the expected placeholder text', ->
         executeStep 'the "Test Input" should have the placeholder text "Fake Placeholder"', (stepResult) ->
-          expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+          expect(stepResult.isFailed()).to.equal true
 
   describe 'the "___" should be enabled', ->
 
@@ -784,11 +784,11 @@ describe 'General Step Defs', ->
 
         it 'should succeed if it expects the button to be enabled', ->
           executeStep 'the "Test" button should be enabled', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+            expect(stepResult.isSuccessful()).to.equal true
 
         it 'should fail if it expects the button to be disabled', ->
           executeStep 'the "Test" button should not be enabled', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+            expect(stepResult.isFailed()).to.equal true
 
       describe 'with disabled button', ->
 
@@ -802,11 +802,11 @@ describe 'General Step Defs', ->
 
         it 'should fail if it expects the button to be enabled', ->
           executeStep 'the "Test" button should be enabled', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+            expect(stepResult.isFailed()).to.equal true
 
         it 'should succeed if it expects the button to be disabled', ->
           executeStep 'the "Test" button should not be enabled', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+            expect(stepResult.isSuccessful()).to.equal true
 
   describe '"___" should be selected in the "___" drop down list', ->
 
@@ -850,11 +850,11 @@ describe 'General Step Defs', ->
 
       it 'should succeed if the expected option is selected', ->
         executeStep '"Eastern Standard" should be selected in the "Time Zone" drop down list', (stepResult) ->
-          expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+          expect(stepResult.isSuccessful()).to.equal true
 
       it 'should fail if the expected option is not selected', ->
         executeStep '"Mountain Standard" should be selected in the "Time Zone" drop down list', (stepResult) ->
-          expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+          expect(stepResult.isFailed()).to.equal true
 
   describe 'the "___" should be checked', ->
 
@@ -895,11 +895,11 @@ describe 'General Step Defs', ->
 
         it 'should succeed if it expects the checkbox to be selected', ->
           executeStep 'the "Test" checkbox should be checked', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+            expect(stepResult.isSuccessful()).to.equal true
 
         it 'should fail if it expects the checkbox to not be selected', ->
           executeStep 'the "Test" checkbox should not be checked', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+            expect(stepResult.isFailed()).to.equal true
 
       describe 'with an unselected checkbox', ->
 
@@ -913,8 +913,8 @@ describe 'General Step Defs', ->
 
         it 'should fail if it expects the checkbox to be selected', ->
           executeStep 'the "Test" checkbox should be checked', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.FAILED
+            expect(stepResult.isFailed()).to.equal true
 
         it 'should succeed if it expects the checkbox to not be selected', ->
           executeStep 'the "Test" checkbox should not be checked', (stepResult) ->
-            expect(stepResult.getStatus()).to.equal Cucumber.Status.PASSED
+            expect(stepResult.isSuccessful()).to.equal true


### PR DESCRIPTION
Locks down the final peer deps for CukeFarm 2.x; see #30 for details on why these versions were chosen and what we'll be supporting for in CukeFarm 3.x