### PR TITLE
Remove default value for tags

### DIFF
--- a/src/protractor.conf.coffee
+++ b/src/protractor.conf.coffee
@@ -12,7 +12,6 @@ module.exports.config =
 
   cucumberOpts:
     require: [rek.path 'GeneralStepDefs']
-    tags: []
     format: 'pretty'
 
   onPrepare: ->


### PR DESCRIPTION
Currently the default value for `cucumberOpts.tags` in `protractor.conf.coffee` is an empty array. This causes issues when passed to `protractor-cucumber-framework`. (See [this issue](https://github.com/mattfritz/protractor-cucumber-framework/issues/10)) Configuring an empty array as a setting is not a good practice anyway, and should be removed.

Fixing this in CukeFarm is a breaking change as users will no longer be able to specify the tags in their own configuration files using the format

    var config = require('cukefarm').config;
    config.cucumberOpts.tags.push('@myTag');

However, this change should have occurred in v3.0.0, which is less than 24 hours old, so my preference would be to unpublish v3.0.0 and publish the fix as v3.0.1 as opposed to publishing the fix as v4.0.0 . I'm open to differing opinions though.