### PR TITLE
Remove default value for tags

### DIFF
--- a/src/protractor.conf.coffee
+++ b/src/protractor.conf.coffee
@@ -12,7 +12,6 @@ module.exports.config =
 
   cucumberOpts:
     require: [rek.path 'GeneralStepDefs']
-    tags: []
     format: 'pretty'
 
   onPrepare: ->


### PR DESCRIPTION
After doing some more thinking about my comment in #33, I decided that I really shouldn't unpublish a version of CukeFarm, but I still don't think this change is worth cutting a new major version, especially with a workaround in `protractor-cucumber-framework` [in the works](https://github.com/mattfritz/protractor-cucumber-framework/pull/11). Given that, I decided to spend some time [defining what branching strategy will be used for CukeFarm](https://github.com/ReadyTalk/cukefarm/wiki/Branching). Given the final result, I'm changing the target branch to `version-4`.