### PR TITLE
Removed the use of rekuire from cukefarm

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
-rek = require('rekuire');
-World = rek('World').World;
-config = rek('protractor.conf').config;
+World = require('./lib/support/World.js').World;
+config = require('./lib/protractor.conf.js').config;
 
 module.exports = {
   World: World,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "js-fixtures": "^1.5.1",
     "mocha": "^2.3.4",
     "protractor-cucumber-framework": "^0.3.0",
-    "rekuire": "^0.1.5",
     "sinon": "^1.10.3",
     "sinon-as-promised": "^4.0.0",
     "time-grunt": "^1.0.0"
@@ -52,10 +51,5 @@
     "test": "grunt",
     "test-firefox": "grunt ci:firefox",
     "test-chrome": "grunt ci:chrome"
-  },
-  "rekuire": {
-    "ignore": [
-      "src"
-    ]
-  }
+  }  
 }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
   "dependencies": {
     "chai": "^3.4.0",
     "chai-as-promised": "^5.0.0",
-    "q": "^1.0.1",
-    "rekuire": "^0.1.5"
+    "q": "^1.0.1"
   },
   "author": "Nathan Thompson",
   "license": "MIT",
   "devDependencies": {
     "coffee-script": "^1.9.1",
+    "coffeelint": "^1.14.2",
     "cucumber": "~0.9.0",
     "docha": "^0.1.2",
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "js-fixtures": "^1.5.1",
     "mocha": "^2.3.4",
     "protractor-cucumber-framework": "^0.3.0",
+    "rekuire": "^0.1.5",
     "sinon": "^1.10.3",
     "sinon-as-promised": "^4.0.0",
     "time-grunt": "^1.0.0"

--- a/spec/elementHelper.spec.coffee
+++ b/spec/elementHelper.spec.coffee
@@ -1,12 +1,11 @@
 chai = require 'chai'
 chaiAsPromised = require 'chai-as-promised'
-rek = require 'rekuire'
 
 chai.use chaiAsPromised
 expect = chai.expect
 
-ElementHelper = rek 'ElementHelper'
-{World} = rek 'World'
+ElementHelper = require '../lib/support/ElementHelper.js'
+{World} = require '../lib/support/World.js'
 
 describe 'elementHelper', ->
 

--- a/spec/generalStepDefs.spec.coffee
+++ b/spec/generalStepDefs.spec.coffee
@@ -1,15 +1,15 @@
-rek = require 'rekuire'
 Cucumber = require 'cucumber'
 sinon = require 'sinon'
 Promise = require 'q'
 sinonAsPromised = require('sinon-as-promised')(Promise)
+path = require 'path'
 {expect} = require 'chai'
 
-{World} = rek 'World'
+{World} = require '../lib/support/World.js'
 
 describe 'General Step Defs', ->
 
-  supportCodeFilePaths = [rek.path 'GeneralStepDefs']
+  supportCodeFilePaths = [path.resolve './lib/step_definitions/GeneralStepDefs.js']
   supportCodeLibrary = Cucumber.Cli.SupportCodeLoader(supportCodeFilePaths, []).getSupportCodeLibrary()
   required_options = { strict: false, failFast: false, dryRun: false }
   required_listener = [Cucumber.Listener()]

--- a/spec/transform.spec.coffee
+++ b/spec/transform.spec.coffee
@@ -1,8 +1,7 @@
 {expect} = require 'chai'
-rek = require 'rekuire'
 
-Transform = rek 'Transform'
-{World} = rek 'World'
+Transform = require '../lib/support/Transform.js'
+{World} = require '../lib/support/World.js'
 
 describe 'transform', ->
 

--- a/src/protractor.conf.coffee
+++ b/src/protractor.conf.coffee
@@ -1,5 +1,4 @@
 path = require 'path'
-rek = require 'rekuire'
 
 module.exports.config =
   framework: 'custom'
@@ -11,7 +10,7 @@ module.exports.config =
       args: ['--test-type']   # Disable the "unsupported flag" prompt. See: https://github.com/angular/protractor/issues/835
 
   cucumberOpts:
-    require: [rek.path 'GeneralStepDefs']
+    require: [path.resolve './node_modules/cukefarm/lib/step_definitions/GeneralStepDefs.js']
     tags: []
     format: 'pretty'
 

--- a/src/support/World.coffee
+++ b/src/support/World.coffee
@@ -1,8 +1,7 @@
-rek = require 'rekuire'
 chai = require 'chai'
 chaiAsPromised = require 'chai-as-promised'
-ElementHelper = rek 'ElementHelper'
-Transform = rek 'Transform'
+ElementHelper = require './ElementHelper.js'
+Transform = require './Transform.js'
 
 class World
   Q: require 'q'


### PR DESCRIPTION
Removed the use of rekuire based on this discussion [thread](https://github.com/ReadyTalk/cukefarm/issues/35).

* Added coffeelint to dev-dependencies (not sure it's needed since my local version needed it)
* Found a work around for pathing for the GeneralStepDefs.js instead of having to have user include it directly.
* Ran unit tests - had lint errors for not being on a unix based box, but no other errors encountered, please verify.