### PR TITLE
Upgrade Cucumber to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Nathan Thompson",
   "license": "MIT",
   "devDependencies": {
-    "cucumber": "^3.0.0",
+    "cucumber": "^4.0.0",
     "docha": "git://github.com/thompsnm/docha#09b60cd",
     "express": "^4.14.1",
     "js-fixtures": "^1.5.3",
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "protractor-cucumber-framework": "^4.0.0",
-    "cucumber": "^3.0.0",
+    "cucumber": "^4.0.0",
     "protractor": "^5.0.0"
   },
   "homepage": "https://github.com/ReadyTalk/cukefarm",


### PR DESCRIPTION
Once PR #54 is merged this PR can be redirected to point to master. Merging this PR will complete the work for #51 and allow us to deprecate CukeFarm version 4.x as per #53 .